### PR TITLE
Remove pprint since it's part of the standard library.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 yara-python
 plyara>=2.1.0
-pprint


### PR DESCRIPTION
The requirement pprint was removed since it caused an error when running `pip install -r requirements.txt`: 

```
ERROR: Could not find a version that satisfies the requirement pprint (from versions: none)
ERROR: No matching distribution found for pprint
```

This is due to the fact that there is no package pprint in package index, since pprint is part of Python's standard library. 