### PR TITLE
Handle ValueError raised by binascii.unhexlify() in string_checks.py

### DIFF
--- a/main/string_checks.py
+++ b/main/string_checks.py
@@ -178,6 +178,8 @@ def analyze_strings(self, rule):
 					pass
 				except UnicodeDecodeError:
 					pass
+				except ValueError:
+					pass
 
 			# MODIFIER ONLY ISSUES ---------------------------------------
 


### PR DESCRIPTION
`analyze_strings()` treats hex-string decoding as `best-effort` and ignores `binascii.Error` and `UnicodeDecodeError`.

`binascii.unhexlify()` can also raise `ValueError` when the input contains non-ASCII characters. This exception currently propagates and aborts rule evaluation.

Handle ValueError in the same way as the existing decode failures so that malformed or unsupported strings do not terminate the QA process.